### PR TITLE
Reimplement separated functions

### DIFF
--- a/interfact-admin-dashboard/src/app/Intersection/[id]/page.tsx
+++ b/interfact-admin-dashboard/src/app/Intersection/[id]/page.tsx
@@ -13,6 +13,8 @@ import { Log } from '@/app/types/Firebase/LogMySql';
 import { calculateTotalBlocks } from '@/app/utils/calculateTotalBlocks';
 import { calculateAverageBlockageTime } from '@/app/utils/calculateAverageBlockageTime';
 import { deleteFromDB } from '@/app/DAOs/Firebase/intersectionsDAO';
+import { confirmReport } from '@/app/utils/intersection/confirmReport';
+import { denyReport } from '@/app/utils/intersection/denyReport';
 
 
 const LOGS_PER_PAGE = 250;
@@ -95,50 +97,7 @@ const IntersectionPage = () => {
     }
   }, [userFeedback, logs]);
 
-  const confirmReport = async (url: string, logID: string, currentStatus: string) => {
-    try {
-      const newStatus = currentStatus === "BLOCKED" ? "OPEN" : "BLOCKED";
-      const updateStatusResponse = await fetch('/api/logs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ logid: logID, status: newStatus }),
-      });
-
-      const updateStatusData = await updateStatusResponse.json();
-
-      if (updateStatusResponse.ok) {
-        console.log(`Status updated to ${newStatus} for logID: ${logID}`);
-      } else {
-        console.error("Error updating status:", updateStatusData.message);
-        return;
-      }
-
-      deleteFromDB(logID);
-
-
-      const confirmResponse = await fetch('/api/report', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
-      });
-
-      const confirmData = await confirmResponse.json();
-
-      if (!confirmResponse.ok) {
-        console.error("Error confirming report:", confirmData.message);
-      }
-    } catch (error) {
-      console.error('Request failed:', error);
-    }
-  };
-
-  const denyReport = async (logID: string) => {
-    try {
-      deleteFromDB(logID);
-    } catch (error) {
-      console.error('Error removing report:', error);
-    }
-  };
+ 
 
   const getTimeColor = (score: number): string => {
     if (score <= 1) return 'green';

--- a/interfact-admin-dashboard/src/app/Intersection/[id]/page.tsx
+++ b/interfact-admin-dashboard/src/app/Intersection/[id]/page.tsx
@@ -15,6 +15,7 @@ import { calculateAverageBlockageTime } from '@/app/utils/calculateAverageBlocka
 import { deleteFromDB } from '@/app/DAOs/Firebase/intersectionsDAO';
 import { confirmReport } from '@/app/utils/intersection/confirmReport';
 import { denyReport } from '@/app/utils/intersection/denyReport';
+import { getTimeColor } from '@/app/utils/intersection/getTimeColor';
 
 
 const LOGS_PER_PAGE = 250;
@@ -99,21 +100,6 @@ const IntersectionPage = () => {
 
  
 
-  const getTimeColor = (score: number): string => {
-    if (score <= 1) return 'green';
-    switch (score) {
-      case 2: return '#FA9E9E';
-      case 3: return '#F87777';
-      case 4: return '#F76464';
-      case 5: return '#F65151';
-      case 6: return '#F53D3D';
-      case 7: return '#F42A2A';
-      case 8: return '#F31616';
-      case 9: return '#E90C0C';
-      case 10: return '#C20A0A';
-      default: return 'green';
-    }
-  };
 
   // Filter logs for the current intersection
   const filteredLogs = intersection ? logs.filter(log => log.cameraid === intersection.id) : [];

--- a/interfact-admin-dashboard/src/app/dashboard/page.tsx
+++ b/interfact-admin-dashboard/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { useLogs } from '../hooks/useLogs';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import calculateDifferenceInMinutes from "../utils/dashboard/timeCaculator";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 
 
 export default function Dashboard() {
@@ -104,21 +105,7 @@ export default function Dashboard() {
     const tabToggle = () => setIsShortcutTabExpanded(!isShortcutTabExpanded);
     // ------------------------- Keyboard shortcuts -------------------------
     
-    useEffect(() => {
-        const handleKeyPress = (event: KeyboardEvent) => {
-
-            if (event.key.toLowerCase() === 'r') {
-                router.push('/requests');
-            }
-        };
-        // EventListener is needed for keydown events
-        document.addEventListener('keydown', handleKeyPress);
-
-        return () => {
-            document.removeEventListener('keydown', handleKeyPress);
-        };
-    }, [router]);
-
+    useKeyboardShortcuts();
 
     // ------------------------- Popup Close -------------------------
     useEffect(() => {

--- a/interfact-admin-dashboard/src/app/hooks/useKeyboardShortcuts.ts
+++ b/interfact-admin-dashboard/src/app/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export const useKeyboardShortcuts = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "r") {
+        router.push("/requests");
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyPress);
+    return () => {
+      document.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [router]);
+};

--- a/interfact-admin-dashboard/src/app/utils/intersection/confirmReport.ts
+++ b/interfact-admin-dashboard/src/app/utils/intersection/confirmReport.ts
@@ -1,0 +1,41 @@
+import { deleteFromDB } from '@/app/DAOs/Firebase/intersectionsDAO';
+
+export const confirmReport = async (
+  url: string,
+  logID: string,
+  currentStatus: string
+): Promise<void> => {
+  try {
+    const newStatus = currentStatus === "BLOCKED" ? "OPEN" : "BLOCKED";
+    const updateStatusResponse = await fetch('/api/logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ logid: logID, status: newStatus }),
+    });
+
+    const updateStatusData = await updateStatusResponse.json();
+
+    if (updateStatusResponse.ok) {
+      console.log(`Status updated to ${newStatus} for logID: ${logID}`);
+    } else {
+      console.error("Error updating status:", updateStatusData.message);
+      return;
+    }
+
+    deleteFromDB(logID);
+
+    const confirmResponse = await fetch('/api/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+
+    const confirmData = await confirmResponse.json();
+
+    if (!confirmResponse.ok) {
+      console.error("Error confirming report:", confirmData.message);
+    }
+  } catch (error) {
+    console.error('Request failed:', error);
+  }
+};

--- a/interfact-admin-dashboard/src/app/utils/intersection/denyReport.ts
+++ b/interfact-admin-dashboard/src/app/utils/intersection/denyReport.ts
@@ -1,0 +1,9 @@
+import { deleteFromDB } from '@/app/DAOs/Firebase/intersectionsDAO';
+
+export const denyReport = async (logID: string): Promise<void> => {
+  try {
+    deleteFromDB(logID);
+  } catch (error) {
+    console.error('Error removing report:', error);
+  }
+};

--- a/interfact-admin-dashboard/src/app/utils/intersection/getTimeColor.ts
+++ b/interfact-admin-dashboard/src/app/utils/intersection/getTimeColor.ts
@@ -1,0 +1,16 @@
+export const getTimeColor = (score: number): string => {
+    if (score <= 1) return 'green';
+    switch (score) {
+      case 2: return '#FA9E9E';
+      case 3: return '#F87777';
+      case 4: return '#F76464';
+      case 5: return '#F65151';
+      case 6: return '#F53D3D';
+      case 7: return '#F42A2A';
+      case 8: return '#F31616';
+      case 9: return '#E90C0C';
+      case 10: return '#C20A0A';
+      default: return 'green';
+    }
+  };
+  


### PR DESCRIPTION
These are functions from the previous hfuncs2 branch, which Ethan authored. Two functions are absent that were in the branch, intentionally so, because:
 1) in order for getReports to show only the right intersections reports, it has to correlate with useLogs, and I want as few calls to the giant mysql as possible, so it just needs to use the one already present in intersection page.tsx. 
2) The filters change their visuals via useState variables, and those just don't work well when extracted.